### PR TITLE
[사용자] (Feature/042) 커스텀 예외 클래스, 에러 코드 추가

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.sprint.team2.monew.domain.user.exception;
+
+public class EmailAlreadyExistsException extends UserException {
+    public EmailAlreadyExistsException() {
+        super(UserErrorCode.EMAIL_ALREADY_EXISTS);
+    }
+    public static EmailAlreadyExistsException emailDuplicated(String email) {
+        EmailAlreadyExistsException exception = new EmailAlreadyExistsException();
+        exception.addDetail("email", email);
+        return exception;
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/EmailAlreadyExistsException.java
@@ -4,6 +4,7 @@ public class EmailAlreadyExistsException extends UserException {
     public EmailAlreadyExistsException() {
         super(UserErrorCode.EMAIL_ALREADY_EXISTS);
     }
+
     public static EmailAlreadyExistsException emailDuplicated(String email) {
         EmailAlreadyExistsException exception = new EmailAlreadyExistsException();
         exception.addDetail("email", email);

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/ForbiddenUserAuthorityException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/ForbiddenUserAuthorityException.java
@@ -1,0 +1,17 @@
+package com.sprint.team2.monew.domain.user.exception;
+
+import com.sprint.team2.monew.global.constant.ErrorCode;
+
+public class ForbiddenUserAuthorityException extends UserException {
+    public ForbiddenUserAuthorityException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static ForbiddenUserAuthorityException forUpdate() {
+        return new ForbiddenUserAuthorityException(UserErrorCode.FORBIDDEN_USER_UPDATE);
+    }
+
+    public static ForbiddenUserAuthorityException forDelete() {
+        return new ForbiddenUserAuthorityException(UserErrorCode.FORBIDDEN_USER_DELETE);
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/InvalidUserCredentialsException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/InvalidUserCredentialsException.java
@@ -1,0 +1,11 @@
+package com.sprint.team2.monew.domain.user.exception;
+
+public class InvalidUserCredentialsException extends UserException {
+    public InvalidUserCredentialsException() {
+        super(UserErrorCode.INVALID_USER_CREDENTIALS);
+    }
+    public static InvalidUserCredentialsException wrongPassword() {
+        InvalidUserCredentialsException exception = new InvalidUserCredentialsException();
+        return exception;
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/InvalidUserCredentialsException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/InvalidUserCredentialsException.java
@@ -4,8 +4,8 @@ public class InvalidUserCredentialsException extends UserException {
     public InvalidUserCredentialsException() {
         super(UserErrorCode.INVALID_USER_CREDENTIALS);
     }
+
     public static InvalidUserCredentialsException wrongPassword() {
-        InvalidUserCredentialsException exception = new InvalidUserCredentialsException();
-        return exception;
+        return new InvalidUserCredentialsException();
     }
 }

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/UserErrorCode.java
@@ -3,15 +3,16 @@ package com.sprint.team2.monew.domain.user.exception;
 import com.sprint.team2.monew.global.constant.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    USER_NOT_FOUND(404, "사용자 정보가 없습니다."),
-    EMAIL_ALREADY_EXISTS(409, "중복된 이메일로 가입할 수 없습니다."),
-    INVALID_USER_CREDENTIALS(401, "이메일 또는 비밀번호가 일치하지 않습니다."),
-    FORBIDDEN_USER_UPDATE(403, "해당 사용자에 대한 수정 권한이 없습니다."),
-    FORBIDDEN_USER_DELETE(403, "해당 사용자에 대한 삭제 권한이 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자 정보가 없습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "중복된 이메일로 가입할 수 없습니다."),
+    INVALID_USER_CREDENTIALS(HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 일치하지 않습니다."),
+    FORBIDDEN_USER_UPDATE(HttpStatus.FORBIDDEN.value(), "해당 사용자에 대한 수정 권한이 없습니다."),
+    FORBIDDEN_USER_DELETE(HttpStatus.FORBIDDEN.value(), "해당 사용자에 대한 삭제 권한이 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,23 @@
+package com.sprint.team2.monew.domain.user.exception;
+
+import com.sprint.team2.monew.global.constant.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(404, "사용자 정보가 없습니다."),
+    EMAIL_ALREADY_EXISTS(409, "중복된 이메일로 가입할 수 없습니다."),
+    INVALID_USER_CREDENTIALS(401, "이메일 또는 비밀번호가 일치하지 않습니다."),
+    FORBIDDEN_USER_UPDATE(403, "해당 사용자에 대한 수정 권한이 없습니다."),
+    FORBIDDEN_USER_DELETE(403, "해당 사용자에 대한 삭제 권한이 없습니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public String getErrorCodeName() {
+        return name();
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/UserException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.sprint.team2.monew.domain.user.exception;
+
+import com.sprint.team2.monew.global.constant.ErrorCode;
+import com.sprint.team2.monew.global.error.BusinessException;
+
+public class UserException extends BusinessException {
+    public UserException(ErrorCode errorCode) {
+      super(errorCode);
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/UserException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/UserException.java
@@ -5,6 +5,6 @@ import com.sprint.team2.monew.global.error.BusinessException;
 
 public class UserException extends BusinessException {
     public UserException(ErrorCode errorCode) {
-      super(errorCode);
+        super(errorCode);
     }
 }

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.sprint.team2.monew.domain.user.exception;
+
+import java.util.UUID;
+
+public class UserNotFoundException extends UserException {
+    public UserNotFoundException() {
+        super(UserErrorCode.USER_NOT_FOUND);
+    }
+    public static UserNotFoundException withId(UUID userId) {
+        UserNotFoundException exception = new UserNotFoundException();
+        exception.addDetail("userId", userId);
+        return exception;
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/exception/UserNotFoundException.java
@@ -6,6 +6,7 @@ public class UserNotFoundException extends UserException {
     public UserNotFoundException() {
         super(UserErrorCode.USER_NOT_FOUND);
     }
+
     public static UserNotFoundException withId(UUID userId) {
         UserNotFoundException exception = new UserNotFoundException();
         exception.addDetail("userId", userId);


### PR DESCRIPTION
## 📌 PR 내용 요약
- 커스텀 예외 클래스 추가 (`domain.user.exception.UserException`)
  -  `EmailAlreadyExistsException`
  - `ForbiddenUserAuthorityException`
  - `InvalidUserCredentialsException`
  - `UserException`
  - `UserNotFoundException`

- 에러 코드 추가 (`domain.user.exception.UserErrorCode`)
  -  `USER_NOT_FOUND`
  - `EMAIL_ALREADY_EXISTS`
  - `INVALID_USER_CREDENTIALS`
  - `FORBIDDEN_USER_UPDATE`
  - `FORBIDDEN_USER_DELETE`


- Swagger API를 참고하여 작성하였습니다.

## 🔗 관련 이슈
- Closes #42 

## 🙋 리뷰어에게 요청사항
- `ErrorCode` 명칭과 메시지가 적절한지 확인해주시면 감사하겠습니다.
  - `HttpStatus.value()`로 로직 변경하였습니다.
