### PR TITLE
[CI/CD] (Feature/033) RDS 연동 & application-prod 수정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# ignoring Gradle cache and build outputs
+.gradle
+/build
+
+# ignoring IDE files and local logs
+.idea
+*.iml
+*.log
+
+# ignoring Git files
+.git
+.gitignore

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: 버그 리포트
+title: "[BUG] "
+labels: Fix
+assignees: ''
+
+---
+
+## 개요
+
+## 상세 설명
+-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: 기능 개발
+title: "[FEAT] "
+labels: Feat
+assignees: ''
+
+---
+
+## 개요
+
+
+## 상세 설명
+- 로직 설명
+
+## 제약 조건
+-
+
+## 선행 구현
+-

--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -1,0 +1,16 @@
+---
+name: Test
+about: 테스트 관련 코드 작성
+title: "[TEST] "
+labels: Test
+assignees: ''
+
+---
+
+## 개요
+
+## 테스트 대상
+- 
+
+## 상세 설명
+-

--- a/.github/ISSUE_TEMPLATE/todo.md
+++ b/.github/ISSUE_TEMPLATE/todo.md
@@ -1,0 +1,16 @@
+---
+name: ToDo
+about: 할 일 목록
+title: "[ 이름 | 날짜(MMDD) ]"
+labels: Todo
+assignees: ''
+
+---
+
+## 작업 내용
+
+
+## 세부 할 일
+  - [ ]  - 001
+  - [ ]  - 002
+  - [ ]  - 003

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,41 @@
-FROM ubuntu:latest
-LABEL authors="applw"
+ARG BUILDER_IMAGE=gradle:7.6.0-jdk17
+ARG RUNTIME_IMAGE=amazoncorretto:17.0.7-alpine
 
-ENTRYPOINT ["top", "-b"]
+# =================== builder ===================
+FROM ${BUILDER_IMAGE} AS builder
+WORKDIR /app
+ENV GRADLE_USER_HOME=/home/gradle/.gradle
+
+USER root
+# making director if non-existent
+RUN mkdir -p ${GRADLE_USER_HOME} && chown -R gradle:gradle /home/gradle /app
+
+USER gradle
+# gradlew - executable file
+COPY --chown=gradle:gradle gradlew ./
+# gradle - gradle wrapper directory
+COPY --chown=gradle:gradle gradle ./gradle
+# other related files: settings.gradle, build.gradle
+COPY --chown=gradle:gradle settings.gradle build.gradle ./
+
+# downloading dependencies in container
+RUN chmod +x ./gradlew
+RUN ./gradlew --no-daemon dependencies || true
+
+# moving MY src to container's src
+COPY --chown=gradle:gradle src ./src
+# create .jar file in container
+RUN ./gradlew clean build --no-daemon --no-parallel -x test
+# verification
+RUN ls -l /app/build/libs
+
+# =================== runtime ===================
+FROM ${RUNTIME_IMAGE}
+WORKDIR /app
+ENV SPRING_PROFILES_ACTIVE=prod
+ENV JVM_OPTS=""
+
+# copying only the built .jar file (in previous build stage - builder) to final image
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 80
+ENTRYPOINT ["sh", "-c", "java $JVM_OPTS -jar app.jar"]

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,9 +3,12 @@ server:
 
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
+#    url: ${SPRING_DATASOURCE_URL}
+#    username: ${SPRING_DATASOURCE_USERNAME}
+#    password: ${SPRING_DATASOURCE_PASSWORD}
+    url: ${POSTGRESQL_DATASOURCE_URL}
+    username: ${POSTGRESQL_DATASOURCE_USERNAME}
+    password: ${POSTGRESQL_DATASOURCE_PASSWORD}
   jpa:
     properties:
       hibernate:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,12 +8,15 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     properties:
+#      hibernate:
+#        format_sql: false
       hibernate:
-        format_sql: false
+        ddl-auto: validate
 
   sql:
     init:
-      mode: always
+#      mode: always
+      mode: never
 
 logging:
   level:


### PR DESCRIPTION
## PR 제목 규칙
[CI/CD] (Feature/033) RDS 연동 & application-prod 수정

## 📌 PR 내용 요약
-  RDS 연동 완료
- application-prod yaml 파일 수정

## 🔗 관련 이슈
- Closes #33 

## 🖼️ 스크린샷 (선택)
- x

## 📚 참고자료 (선택)
- x

## 🙋 리뷰어에게 요청사항
- application-prod만 봐주시면 됩니다!
  - ddl-auto: validate
    - prod 환경에서는 RDS를 DataGrip과 연결을 하고 schema.sql을 통해 이미 테이블을 생성해주어서 validate를 사용하면 좋을것 같습니다
    - sql.init.mode:never 로 바꾸었습니다
