### PR TITLE
[예외처리] (Feature/081) 전역 예외 처리 - BaseErrorCode, DomainException 추가

### DIFF
--- a/src/main/java/com/sprint/team2/monew/global/error/BaseErrorCode.java
+++ b/src/main/java/com/sprint/team2/monew/global/error/BaseErrorCode.java
@@ -2,11 +2,12 @@ package com.sprint.team2.monew.global.error;
 
 import com.sprint.team2.monew.global.constant.ErrorCode;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum BaseErrorCode implements ErrorCode {
-    INVALID_INPUT_VALUE(400, "잘못된 입력값입니다."),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다.");
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST.value(), "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/sprint/team2/monew/global/error/BaseErrorCode.java
+++ b/src/main/java/com/sprint/team2/monew/global/error/BaseErrorCode.java
@@ -1,0 +1,23 @@
+package com.sprint.team2.monew.global.error;
+
+import com.sprint.team2.monew.global.constant.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public enum BaseErrorCode implements ErrorCode {
+    INVALID_INPUT_VALUE(400, "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다.");
+
+    private final int status;
+    private final String message;
+
+    BaseErrorCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public String getErrorCodeName() {
+        return name();
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/global/error/BusinessException.java
+++ b/src/main/java/com/sprint/team2/monew/global/error/BusinessException.java
@@ -10,30 +10,37 @@ import java.util.Map;
 @Getter
 public class BusinessException extends RuntimeException {
 
-  private final ErrorCode errorCode;
-  private final Instant timestamp;
-  private final Map<String, Object> details;
+    private final ErrorCode errorCode;
+    private final Instant timestamp;
+    private final Map<String, Object> details;
 
-  public BusinessException(ErrorCode errorCode) {
-    super(errorCode.getMessage());
-    this.errorCode = errorCode;
-    this.timestamp = Instant.now();
-    this.details = new HashMap<>();
-  }
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.timestamp = Instant.now();
+        this.details = new HashMap<>();
+    }
 
-  public void addDetail(String key, Object value) {
-    this.details.put(key, value);
-  }
+    public BusinessException(ErrorCode errorCode, Map<String, Object> details) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.timestamp = Instant.now();
+        this.details = details;
+    }
 
-  public int getStatus() {
-    return errorCode.getStatus();
-  }
+    public void addDetail(String key, Object value) {
+        this.details.put(key, value);
+    }
 
-  public String getMessage() {
-    return errorCode.getMessage();
-  }
+    public int getStatus() {
+        return errorCode.getStatus();
+    }
 
-  public String getErrorCodeName() {
-    return errorCode.getErrorCodeName();
-  }
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    public String getErrorCodeName() {
+        return errorCode.getErrorCodeName();
+    }
 }

--- a/src/main/java/com/sprint/team2/monew/global/error/DomainException.java
+++ b/src/main/java/com/sprint/team2/monew/global/error/DomainException.java
@@ -1,0 +1,9 @@
+package com.sprint.team2.monew.global.error;
+
+import java.util.Map;
+
+public class DomainException extends BusinessException {
+    public DomainException(Map<String, Object> details) {
+        super(BaseErrorCode.INVALID_INPUT_VALUE, details);
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprint/team2/monew/global/error/GlobalExceptionHandler.java
@@ -3,26 +3,49 @@ package com.sprint.team2.monew.global.error;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ErrorResponse> handleException(Exception e) {
-    log.error("예상치 못한 오류 발생: {}", e.getMessage(), e);
-    ErrorResponse errorResponse = new ErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR.value());
-    return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(errorResponse);
-  }
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("예상치 못한 오류 발생: {}", e.getMessage(), e);
+        ErrorResponse errorResponse = new ErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR.value());
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse);
+    }
 
-  @ExceptionHandler(BusinessException.class)
-  public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
-    log.error("커스텀 예외 발생: code={}, message={}", e.getErrorCode(), e.getMessage(), e);
-    return ResponseEntity.status(e.getErrorCode().getStatus())
-        .body(new ErrorResponse(e));
-  }
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("커스텀 예외 발생: code={}, message={}", e.getErrorCode(), e.getMessage(), e);
+        return ResponseEntity.status(e.getStatus())
+                .body(new ErrorResponse(e));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public void handleValidationExceptions(MethodArgumentNotValidException e) {
+        Map<String, Object> details = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = fieldError.getDefaultMessage();
+            details.put(fieldName, errorMessage);
+        });
+
+        throw new DomainException(details);
+    }
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ErrorResponse> handleDomainException(DomainException e) {
+        log.error("요청 유효성 커스텀 예외 발생: code={}, message={}", e.getErrorCode(), e.getMessage(), e);
+        return ResponseEntity.status(e.getStatus())
+                .body(new ErrorResponse(e));
+    }
 }


### PR DESCRIPTION
## 📌 PR 내용 요약
-  **BaseErrorCode 추가** (`global.error`)
    - `INVALID_INPUT_VALUE(400, "잘못된 입력입니다.")` 
    - `INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다.")`

<br>

- **DomainException 추가** (`global.error`)
  - `BusinessException` 상속
  -  생성자에서 `Map<String, Object> details`를 파라미터로 받아와 생성

<br>

- **BusinessException 생성자 추가**
    - `public BusinessException(ErrorCode errorCode, Map<String, Object> details)`: DomainException에 details을 따로 추가하기 위해 `Map<String, Object> details`를 받는 생성자를 추가하였습니다.

<br>

- **GlobalExceptionHandler에 검증용 커스텀 예외 처리를 위한 에러 핸들러 추가**
  -  `handleValidationExceptions()`: `MethodArgumentNotValidException.class` (검증 예외) 처리
      - `Map<String, Object> details` 생성 후, `details`를 파라미터로 사용하여 DomainException을 던집니다.

  - `handleDomainException()`: `handleValidationExceptions()`에서 던진 DomainException을 받아서 로그를 남긴 후 ResponseEntity의 `body`로 ErrorResponse를 생성하여 반환합니다.

## 🔗 관련 이슈
- Closes #81 

## 🙋 리뷰어에게 요청사항
- GlobalExceptionHandler 생성자 추가 관련: `MethodArgumentNotValidException`(검증 예외)로부터 예외 발생 필드 정보(필드명, 검증 예외 메시지)를 받아와 따로 생성해줘야 할 것 같아서 `details`를 받는 종류의 생성자를 추가하였습니다. 
  - 다른 좋은 아이디어가 있으시다면 추천 부탁드립니다.

- `HttpStatus.value()`로 로직 변경하였습니다.
