### PR TITLE
[관심사] (Feat/017) 관심사 물리 삭제 구현

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/controller/InterestController.java
@@ -45,4 +45,13 @@ public class InterestController {
         log.info("[구독] 구독 취소 응답 완료");
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping(value = "/{interest-id}")
+    public ResponseEntity delete(@PathVariable("interest-id") UUID interestId) {
+        log.info("[관심사] 관심사 삭제 요청 id = {}", interestId);
+        interestService.delete(interestId);
+        log.info("[관심사] 관심사 삭제 응답 완료");
+        return ResponseEntity.noContent().build();
+
+    }
 }

--- a/src/main/java/com/sprint/team2/monew/domain/interest/controller/InterestController.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/controller/InterestController.java
@@ -28,8 +28,8 @@ public class InterestController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PostMapping(value = "/{interest-id}/subscriptions")
-    public ResponseEntity subscriptions(@PathVariable("interest-id") UUID interestId,
+    @PostMapping(value = "/{interestId}/subscriptions")
+    public ResponseEntity subscriptions(@PathVariable("interestId") UUID interestId,
                                         @RequestHeader("MoNew-Request-User-ID") UUID userId) {
         log.info("[관심사] 구독 등록 호출 interestId = {}, userId = {}", interestId, userId);
         SubscriptionDto response = interestService.subscribe(interestId,userId);
@@ -37,8 +37,8 @@ public class InterestController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping(value = "/{interest-id}/subscriptions")
-    public ResponseEntity unsubscribe(@PathVariable("interest-id") UUID interestId,
+    @DeleteMapping(value = "/{interestId}/subscriptions")
+    public ResponseEntity unsubscribe(@PathVariable("interestId") UUID interestId,
                                  @RequestHeader("Monew-Request-User-ID") UUID userId) {
         log.info("[구독] DELETE /api/interests/{interest-id}/subscriptions 구독 취소 API 호출");
         interestService.unsubscribe(interestId, userId);
@@ -46,8 +46,8 @@ public class InterestController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping(value = "/{interest-id}")
-    public ResponseEntity delete(@PathVariable("interest-id") UUID interestId) {
+    @DeleteMapping(value = "/{interestId}")
+    public ResponseEntity delete(@PathVariable("interestId") UUID interestId) {
         log.info("[관심사] 관심사 삭제 요청 id = {}", interestId);
         interestService.delete(interestId);
         log.info("[관심사] 관심사 삭제 응답 완료");

--- a/src/main/java/com/sprint/team2/monew/domain/interest/service/InterestService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/service/InterestService.java
@@ -10,4 +10,5 @@ public interface InterestService {
     void unsubscribe(UUID interestId, UUID userId);
     InterestDto create(InterestRegisterRequest interestRegisterRequest);
     SubscriptionDto subscribe(UUID interestId, UUID userId);
+    void delete(UUID interestId);
 }

--- a/src/main/java/com/sprint/team2/monew/domain/interest/service/basic/BasicInterestService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/service/basic/BasicInterestService.java
@@ -112,6 +112,9 @@ public class BasicInterestService implements InterestService {
 
     private Subscription validateSubscription(UUID interestId, UUID userId) {
         return subscriptionRepository.findByUser_IdAndInterest_Id(userId, interestId)
-                .orElseThrow(() -> SubscriptionNotFoundException.notFound(interestId, userId));
+                .orElseThrow(() -> {
+                    log.error("[구독] 해당 유저는 해당 관심사를 구독중이 아님. userId= {}, interestId = {}", userId, interestId);
+                    return SubscriptionNotFoundException.notFound(interestId, userId);
+                });
     }
 }

--- a/src/main/java/com/sprint/team2/monew/domain/interest/service/basic/BasicInterestService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/service/basic/BasicInterestService.java
@@ -71,17 +71,28 @@ public class BasicInterestService implements InterestService {
         log.info("[구독] 구독 취소 완료");
     }
 
+    @Override
+    @Transactional
+    public void delete(UUID interestId) {
+        log.info("[관심사] 관심사 삭제 호출");
+        Interest interest = validateInterest(interestId);
+        subscriptionRepository.deleteByInterest(interest);
+        log.debug("[구독] 관심사 삭제에 따라 구독 삭제");
+        interestRepository.delete(interest);
+        log.info("[관심사] 관심사 삭제 완료");
+    }
+
     private User validateUser(UUID userId) {
         return userRepository.findById(userId).orElseThrow(() -> {
             log.error("[관심사] 유저를 찾을 수 없음, id = {}", userId);
-            throw UserNotFoundException.withId(userId);
+            return UserNotFoundException.withId(userId);
         });
     }
 
     private Interest validateInterest(UUID interestId) {
         return interestRepository.findById(interestId).orElseThrow(() -> {
             log.error("[관심사] 관심사를 찾을 수 없음, id = {}", interestId);
-            throw InterestNotFoundException.notFound(interestId);
+            return InterestNotFoundException.notFound(interestId);
         });
     }
 

--- a/src/main/java/com/sprint/team2/monew/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/team2/monew/domain/subscription/repository/SubscriptionRepository.java
@@ -1,5 +1,6 @@
 package com.sprint.team2.monew.domain.subscription.repository;
 
+import com.sprint.team2.monew.domain.interest.entity.Interest;
 import com.sprint.team2.monew.domain.subscription.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,5 @@ import java.util.UUID;
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
     boolean existsByInterest_IdAndUser_Id(UUID interestId, UUID userId);
     Optional<Subscription> findByUser_IdAndInterest_Id(UUID userId, UUID interestId);
+    void deleteByInterest(Interest interest);
 }

--- a/src/test/java/com/sprint/team2/monew/domain/interest/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/interest/controller/InterestControllerTest.java
@@ -1,4 +1,4 @@
-package com.sprint.team2.monew.interest.controller;
+package com.sprint.team2.monew.domain.interest.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.team2.monew.domain.interest.controller.InterestController;
@@ -163,4 +163,21 @@ public class InterestControllerTest {
         // then
         resultActions.andExpect(status().is5xxServerError());
     }
+
+    @DisplayName("관심사 ID를 받아서 삭제한다.")
+    @Test
+    void deleteInterestShouldSucceed() throws Exception {
+        // 본문 생성
+        UUID interestId = UUID.randomUUID();
+
+        // given
+        doNothing().when(interestService).delete(interestId);
+
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/interests/{interest-id}",interestId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+        resultActions.andExpect(status().isNoContent());
+    }
+
 }

--- a/src/test/java/com/sprint/team2/monew/domain/interest/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/interest/controller/InterestControllerTest.java
@@ -180,4 +180,14 @@ public class InterestControllerTest {
         resultActions.andExpect(status().isNoContent());
     }
 
+    @DisplayName("관심사ID 형식이 올바르지 않으면 오류를 발생시킨다.")
+    @Test
+    void deleteInterestFailWhenInvalidInterestId() throws Exception {
+        long interestId = 1123L;
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/interests/{interest-id}",interestId)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+        resultActions.andExpect(status().isInternalServerError());
+    }
 }


### PR DESCRIPTION
## PR 제목 규칙
[관심사] (Feat/017) 관심사 물리 삭제 구현

## 📌 PR 내용 요약
- 관심사를 데이터베이스에서 물리적으로 삭제하는 기능 구현
- 관심사 삭제 시 연관관계를 가진 구독도 같이 삭제
- 테스트코드 작성

## 🔗 관련 이슈
- Closes #17 

## 🙋 리뷰어에게 요청사항
- 
