### PR TITLE
[활동 내역] (FEAT/112) 활동 내역 이벤트 리스너 추가

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/user/service/basic/BasicUserService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/user/service/basic/BasicUserService.java
@@ -9,8 +9,10 @@ import com.sprint.team2.monew.domain.user.exception.InvalidUserCredentialsExcept
 import com.sprint.team2.monew.domain.user.mapper.UserMapper;
 import com.sprint.team2.monew.domain.user.repository.UserRepository;
 import com.sprint.team2.monew.domain.user.service.UserService;
+import com.sprint.team2.monew.domain.userActivity.events.UserCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -20,6 +22,9 @@ public class BasicUserService implements UserService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;
+
+    // User Activity 이벤트
+    private final ApplicationEventPublisher publisher;
 
     @Override
     public UserDto create(UserRegisterRequest request) {
@@ -38,6 +43,15 @@ public class BasicUserService implements UserService {
         User savedUser = userRepository.save(userMapper.toEntity(request));
         UserDto result = userMapper.toDto(savedUser);
         log.info("[사용자] 생성 완료 - userId={}", result.id());
+
+        // ============== User Activity 이벤트 추가 ==============
+        publisher.publishEvent(new UserCreatedEvent(
+            savedUser.getId(),
+            savedUser.getEmail(),
+            savedUser.getNickname(),
+            savedUser.getCreatedAt()
+        ));
+
         return result;
     }
 

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/entity/UserActivity.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/entity/UserActivity.java
@@ -1,36 +1,36 @@
 package com.sprint.team2.monew.domain.userActivity.entity;
 
 import com.sprint.team2.monew.domain.article.dto.response.ArticleViewDto;
-import com.sprint.team2.monew.domain.article.entity.Article;
 import com.sprint.team2.monew.domain.base.BaseEntity;
 import com.sprint.team2.monew.domain.comment.dto.response.CommentActivityDto;
-import com.sprint.team2.monew.domain.comment.entity.Comment;
 import com.sprint.team2.monew.domain.subscription.dto.SubscriptionDto;
-import com.sprint.team2.monew.domain.subscription.entity.Subscription;
-import com.sprint.team2.monew.domain.user.entity.User;
 import com.sprint.team2.monew.domain.userActivity.dto.CommentActivityLikeDto;
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.data.annotation.CreatedDate;
+import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+@Getter
 @Document
 public class UserActivity extends BaseEntity {
 
   @Id
-  private UUID id;
-  private LocalDateTime createdAt;
+  private UUID id; // user id
   private String email;
   private String nickname;
+  private LocalDateTime createdAt;
 
   private List<SubscriptionDto> subscriptions;
   private List<CommentActivityDto> comments;
   private List<CommentActivityLikeDto> commentLikes;
   private List<ArticleViewDto> articleViews;
+
+  public UserActivity(UUID id, String email, String nickname) {
+    this.id = id;
+    this.email = email;
+    this.nickname = nickname;
+  }
 
 }

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/events/ArticleViewEvent.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/events/ArticleViewEvent.java
@@ -1,0 +1,20 @@
+package com.sprint.team2.monew.domain.userActivity.events;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class ArticleViewEvent {
+  UUID id; // userId
+  UUID viewedBy;
+  LocalDateTime createdAt;
+  UUID articleId;
+  String source;
+  String sourceUrl;
+  String articleTitle;
+  LocalDateTime articlePublishedDate;
+  String articleSummary;
+  long articleCommentCount;
+  long articleViewCount;
+}

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/events/CommentActivityEvent.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/events/CommentActivityEvent.java
@@ -1,0 +1,18 @@
+package com.sprint.team2.monew.domain.userActivity.events;
+
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CommentActivityEvent {
+  UUID id;
+  UUID articleId;
+  String articleTitle;
+  UUID userId;
+  String userNickname;
+  String content;
+  long likeCount;
+  LocalDateTime createdAt;
+}

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/events/CommentActivityLikeEvent.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/events/CommentActivityLikeEvent.java
@@ -1,0 +1,20 @@
+package com.sprint.team2.monew.domain.userActivity.events;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CommentActivityLikeEvent {
+  UUID id;
+  LocalDateTime createdAt;
+  UUID commentId;
+  UUID articleId;
+  String articleTitle;
+  UUID commentUserId;
+  String commentUserNickname;
+  String commentContent;
+  long commentLikeCount;
+  LocalDateTime commentCreatedAt;
+
+}

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/events/SubscriptionUpdatedEvent.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/events/SubscriptionUpdatedEvent.java
@@ -1,0 +1,18 @@
+package com.sprint.team2.monew.domain.userActivity.events;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SubscriptionUpdatedEvent {
+  UUID id;
+  UUID interestId;
+  String interestName;
+  List<String> interestKeywords;
+  long interestSubscriberCount;
+  LocalDateTime createdAt;
+}

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/events/UserCreatedEvent.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/events/UserCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.sprint.team2.monew.domain.userActivity.events;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserCreatedEvent {
+  private final UUID id; // userid
+  private final String email;
+  private final String nickname;
+  private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/listener/UserActivityListener.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/listener/UserActivityListener.java
@@ -1,0 +1,233 @@
+package com.sprint.team2.monew.domain.userActivity.listener;
+
+import com.sprint.team2.monew.domain.article.dto.response.ArticleViewDto;
+import com.sprint.team2.monew.domain.comment.dto.response.CommentActivityDto;
+import com.sprint.team2.monew.domain.subscription.dto.SubscriptionDto;
+import com.sprint.team2.monew.domain.userActivity.dto.CommentActivityLikeDto;
+import com.sprint.team2.monew.domain.userActivity.entity.UserActivity;
+import com.sprint.team2.monew.domain.userActivity.events.ArticleViewEvent;
+import com.sprint.team2.monew.domain.userActivity.events.CommentActivityEvent;
+import com.sprint.team2.monew.domain.userActivity.events.CommentActivityLikeEvent;
+import com.sprint.team2.monew.domain.userActivity.events.SubscriptionUpdatedEvent;
+import com.sprint.team2.monew.domain.userActivity.events.UserCreatedEvent;
+import com.sprint.team2.monew.domain.userActivity.mapper.UserActivityMapper;
+import com.sprint.team2.monew.domain.userActivity.repository.UserActivityRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserActivityListener {
+
+  /**
+   * 나중에 최적화:
+   * - repository에 @Query, @Update 알아보기
+   */
+
+  public final UserActivityRepository userActivityRepository;
+  public final UserActivityMapper userActivityMapper;
+
+  // ================================== 사용자 ==================================
+  // 사용자 생성
+  @EventListener
+  public void handleUserCreate(UserCreatedEvent event) {
+    UUID id = event.getId();
+    String email = event.getEmail();
+    String nickname = event.getNickname();
+    UserActivity newUserActivity = new UserActivity(
+        id,
+        email,
+        nickname
+    );
+    log.info("[사용자 활동] 생성 시작 - id = {}",id);
+    // save to mongodb
+    userActivityRepository.save(newUserActivity);
+
+    log.info("[사용자 활동] 생성 완료 - id = {}", id);
+  }
+
+  // ================================== 구독 ==================================
+  // 구독 업데이트
+  @EventListener
+  public void handleSubscriptionAdd(SubscriptionUpdatedEvent event) {
+    UUID userId = event.getId();
+    UUID interestId = event.getInterestId();
+    SubscriptionDto subscriptionDto = userActivityMapper.toSubscriptionDto(event);
+
+    log.info("[사용자 활동] 구독 추가 시작 - interestId = {}",interestId);
+
+    UserActivity userActivity = userActivityRepository.findById(userId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
+    List<SubscriptionDto> subscriptionDtos = userActivity.getSubscriptions();
+
+    if (!subscriptionDtos.contains(subscriptionDto)) {
+      subscriptionDtos.add(0, subscriptionDto);
+    }
+
+    if (subscriptionDtos.size() > 10) {
+      subscriptionDtos.remove(subscriptionDtos.size() - 1); // removing oldest item
+    }
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 구독 추가 완료 - interestId = {}", interestId);
+  }
+
+  // 구독 업데이트
+  @EventListener
+  public void handleSubscriptionDelete(SubscriptionUpdatedEvent event) {
+    UUID userId = event.getId();
+    UUID interestId = event.getInterestId();
+    SubscriptionDto subscriptionDto = userActivityMapper.toSubscriptionDto(event);
+
+    log.info("[사용자 활동] 구독 삭제 시작 - interestId = {}",interestId);
+
+    UserActivity userActivity = userActivityRepository.findById(userId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
+    List<SubscriptionDto> subscriptionDtos = userActivity.getSubscriptions();
+
+    userActivity.getSubscriptions()
+        .removeIf(s -> s.interestId().equals(event.getInterestId()));
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 구독 삭제 완료 - interestId = {}", interestId);
+  }
+
+  // ================================== 댓글 (최신 10개) ==================================
+  // 유저 댓글 추가
+  @EventListener
+  public void handleCommentAdd(CommentActivityEvent event) {
+    UUID commentId = event.getId();
+    UUID userId = event.getUserId();
+    CommentActivityDto commentActivityDto = userActivityMapper.toCommentActivityDto(event);
+
+    log.info("[사용자 활동] 댓글 추가 시작 - commentId = {}",commentId);
+
+    UserActivity userActivity = userActivityRepository.findById(userId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
+    List<CommentActivityDto> commentActivityDtos = userActivity.getComments();
+
+    commentActivityDtos.add(0, commentActivityDto);
+
+    if (commentActivityDtos.size() > 10) {
+      commentActivityDtos.remove(commentActivityDtos.size() - 1); // removing oldest item
+    }
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 댓글 추가 완료- commentId = {}", commentId);
+  }
+
+  // 유저 댓글 삭제
+  @EventListener
+  public void handleCommentDelete(CommentActivityEvent event) {
+    UUID commentId = event.getId();
+    UUID userId = event.getUserId();
+
+    log.info("[사용자 활동] 댓글 삭제 시작 - commentId = {}", commentId);
+
+    UserActivity userActivity = userActivityRepository.findById(userId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
+
+    userActivity.getComments()
+        .removeIf(c -> c.id().equals(commentId));
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 댓글 삭제 완료- commentId = {}", commentId);
+  }
+
+  // ================================== 댓글 좋아요 (최신 10개) ==================================
+
+  // 유저 댓글 좋아요
+  @EventListener
+  public void handleCommentLikeAdd(CommentActivityLikeEvent event) {
+    UUID commentId = event.getCommentId();
+    UUID commentUserId = event.getCommentUserId();
+    CommentActivityLikeDto commentActivityLikeDto = userActivityMapper.toCommentActivityLikeDto(event);
+
+    log.info("[사용자 활동] 댓글 좋아요 추가 시작 - commentId = {}",commentId);
+
+    UserActivity userActivity = userActivityRepository.findById(commentUserId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + commentUserId));
+    List<CommentActivityLikeDto> commentActivityLikeDtos = userActivity.getCommentLikes();
+
+    if (!commentActivityLikeDtos.contains(commentActivityLikeDto)) {
+      commentActivityLikeDtos.add(0, commentActivityLikeDto);
+    }
+
+    if (commentActivityLikeDtos.size() > 10) {
+      commentActivityLikeDtos.remove(commentActivityLikeDtos.size() - 1); // removing oldest item
+    }
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 댓글 좋아요 추가 완료 - commentId = {}", commentId);
+  }
+
+  // 유저 댓글 좋아요 취소
+  @EventListener
+  public void handleCommentLikeCancel(CommentActivityLikeEvent event) {
+    UUID commentId = event.getCommentId();
+    UUID commentUserId = event.getCommentUserId();
+
+    log.info("[사용자 활동] 댓글 좋아요 삭제 시작 - commentId = {}", commentId);
+
+    UserActivity userActivity = userActivityRepository.findById(commentUserId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + commentUserId));
+
+    userActivity.getCommentLikes()
+        .removeIf(c -> c.commentId().equals(commentId));
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 댓글 좋아요 삭제 완료 - commentId = {}", commentId);
+
+  }
+
+  // ================================== 읽은 기사 (최신 10개) ==================================
+
+  // 유저가 최근에 읽은 기사
+  @EventListener
+  public void handleArticleViewAdd(ArticleViewEvent event) {
+    UUID userId = event.getId();
+    UUID articleId = event.getArticleId();
+    ArticleViewDto articleViewDto = userActivityMapper.toArticleViewDto(event);
+
+    log.info("[사용자 활동] 읽은 기사 추가 시작 - articleId = {}", articleId);
+
+    UserActivity userActivity = userActivityRepository.findById(userId)
+        // replace with custom error <<<<<<<<<<<<<<<<
+        .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
+    List<ArticleViewDto> articleViewDtos = userActivity.getArticleViews();
+
+//    if (!articleViewDtos.contains(articleViewDto)) {
+//      articleViewDtos.add(0, articleViewDto);
+//    }
+
+    articleViewDtos.add(0, articleViewDto);
+
+    if (articleViewDtos.size() > 10) {
+      articleViewDtos.remove(articleViewDtos.size() - 1); // removing oldest item
+    }
+
+    userActivityRepository.save(userActivity);
+
+    log.info("[사용자 활동] 읽은 기사 추가 완료 - articleId = {}", articleId);
+  }
+}
+
+
+

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/listener/UserActivityListener.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/listener/UserActivityListener.java
@@ -66,9 +66,10 @@ public class UserActivityListener {
         .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
     List<SubscriptionDto> subscriptionDtos = userActivity.getSubscriptions();
 
-    if (!subscriptionDtos.contains(subscriptionDto)) {
-      subscriptionDtos.add(0, subscriptionDto);
-    }
+//    if (!subscriptionDtos.contains(subscriptionDto)) {
+//      subscriptionDtos.add(0, subscriptionDto);
+//    }
+    subscriptionDtos.add(0, subscriptionDto);
 
     if (subscriptionDtos.size() > 10) {
       subscriptionDtos.remove(subscriptionDtos.size() - 1); // removing oldest item
@@ -91,7 +92,6 @@ public class UserActivityListener {
     UserActivity userActivity = userActivityRepository.findById(userId)
         // replace with custom error <<<<<<<<<<<<<<<<
         .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + userId));
-    List<SubscriptionDto> subscriptionDtos = userActivity.getSubscriptions();
 
     userActivity.getSubscriptions()
         .removeIf(s -> s.interestId().equals(event.getInterestId()));
@@ -163,9 +163,11 @@ public class UserActivityListener {
         .orElseThrow(() -> new IllegalStateException("User activity not found for user: " + commentUserId));
     List<CommentActivityLikeDto> commentActivityLikeDtos = userActivity.getCommentLikes();
 
-    if (!commentActivityLikeDtos.contains(commentActivityLikeDto)) {
-      commentActivityLikeDtos.add(0, commentActivityLikeDto);
-    }
+//    if (!commentActivityLikeDtos.contains(commentActivityLikeDto)) {
+//      commentActivityLikeDtos.add(0, commentActivityLikeDto);
+//    }
+
+    commentActivityLikeDtos.add(0, commentActivityLikeDto);
 
     if (commentActivityLikeDtos.size() > 10) {
       commentActivityLikeDtos.remove(commentActivityLikeDtos.size() - 1); // removing oldest item

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/mapper/UserActivityMapper.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/mapper/UserActivityMapper.java
@@ -1,5 +1,23 @@
 package com.sprint.team2.monew.domain.userActivity.mapper;
 
+import com.sprint.team2.monew.domain.article.dto.response.ArticleViewDto;
+import com.sprint.team2.monew.domain.comment.dto.response.CommentActivityDto;
+import com.sprint.team2.monew.domain.subscription.dto.SubscriptionDto;
+import com.sprint.team2.monew.domain.userActivity.dto.CommentActivityLikeDto;
+import com.sprint.team2.monew.domain.userActivity.events.ArticleViewEvent;
+import com.sprint.team2.monew.domain.userActivity.events.CommentActivityEvent;
+import com.sprint.team2.monew.domain.userActivity.events.CommentActivityLikeEvent;
+import com.sprint.team2.monew.domain.userActivity.events.SubscriptionUpdatedEvent;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
 public interface UserActivityMapper {
 
+  ArticleViewDto toArticleViewDto(ArticleViewEvent event);
+
+  SubscriptionDto toSubscriptionDto(SubscriptionUpdatedEvent event);
+
+  CommentActivityDto toCommentActivityDto(CommentActivityEvent event);
+
+  CommentActivityLikeDto toCommentActivityLikeDto(CommentActivityLikeEvent event);
 }


### PR DESCRIPTION
## PR 제목 규칙
[활동 내역] (FEAT/112) 활동 내역 이벤트 리스너 추가

## 📌 PR 내용 요약
- 유저 활동 내역 업데이트 기능 추가: @Eventlistener 사용
  - (UserService에만 )유저의 활동의 업데이트 되면 MongoDB의 데이터가 자동 업데이트 되는 기능 구현
- 매퍼 추가
- 필요한 이벤트 객체들 구현 

## 🔗 관련 이슈
- Closes #112 

## 🖼️ 스크린샷 (선택)
- x

## 📚 참고자료 (선택)
- x

## 🙋 리뷰어에게 요청사항
- UserActivityListener만 보면 됩니다! UserActivity를 만들고 mongodb repository에 따로 저장하는 로직이 들어있습니다.
