### PR TITLE
[사용자] (Fix/153) 서비스 테스트 코드 오류 수정

### DIFF
--- a/src/test/java/com/sprint/team2/monew/domain/user/service/basic/BasicUserServiceTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/user/service/basic/BasicUserServiceTest.java
@@ -11,12 +11,14 @@ import com.sprint.team2.monew.domain.user.exception.LoginFailedException;
 import com.sprint.team2.monew.domain.user.exception.UserNotFoundException;
 import com.sprint.team2.monew.domain.user.mapper.UserMapper;
 import com.sprint.team2.monew.domain.user.repository.UserRepository;
+import com.sprint.team2.monew.domain.userActivity.events.UserCreatedEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -27,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +40,9 @@ class BasicUserServiceTest {
 
     @Mock
     private UserMapper userMapper;
+
+    @Mock
+    ApplicationEventPublisher publisher;
 
     @InjectMocks
     private BasicUserService userService;
@@ -69,6 +75,9 @@ class BasicUserServiceTest {
         );
         given(userMapper.toEntity(request)).willReturn(user);
         given(userMapper.toDto(any(User.class))).willReturn(userDto);
+
+        // 이벤트 퍼블리셔
+        willDoNothing().given(publisher).publishEvent(any(UserCreatedEvent.class));
 
         // when
         UserDto result = userService.create(request);


### PR DESCRIPTION
## 📌 PR 내용 요약
- `createUserSuccess()`에서 테스트 코드 오류가 발생하는 것을 수정하였습니다.

  - `BasicUserService.create()`에 추가된 이벤트 퍼블리셔에 테스트 코드가 대응하지 못해서 생긴 문제였습니다.

  - 이벤트 퍼블리셔를 모킹하고, `willDoNothing()`으로 `given()`처리하여 해결하였습니다. 


## 🔗 관련 이슈
- Closes #153 

## 🙋 리뷰어에게 요청사항
