### PR TITLE
[관심사] (fix/183) 관심사 목록 조회 시 hasNext 동작 변경

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/dto/response/CursorPageResponseInterestDto.java
@@ -24,4 +24,15 @@ public record CursorPageResponseInterestDto<T> (
                 page.hasNext()
         );
     }
+
+    public static <T> CursorPageResponseInterestDto<T> from(Slice<T> slice, String cursor, LocalDateTime after, Long totalElements) {
+        return new CursorPageResponseInterestDto<>(
+                slice.getContent(),
+                cursor,
+                after,
+                slice.getSize(),
+                totalElements,
+                slice.hasNext()
+        );
+    }
 }

--- a/src/main/java/com/sprint/team2/monew/domain/interest/entity/Interest.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/entity/Interest.java
@@ -6,7 +6,9 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Type;
+import org.hibernate.type.SqlTypes;
 
 import java.util.List;
 import java.util.Objects;
@@ -22,7 +24,8 @@ public class Interest extends UpdatableEntity {
     @Column(name = "name", length = 50, nullable = false)
     private String name;
     @Size(min = 1, max = 10)
-    @Column(name = "keywords", columnDefinition = "VARCHAR(20)[]")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "keywords", columnDefinition = "json")
     private List<String> keywords;
     @Column(name="subscription_count")
     private long subscriberCount;

--- a/src/main/java/com/sprint/team2/monew/domain/interest/repository/InterestRepositoryCustom.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/repository/InterestRepositoryCustom.java
@@ -3,9 +3,12 @@ package com.sprint.team2.monew.domain.interest.repository;
 import com.sprint.team2.monew.domain.interest.dto.request.CursorPageRequestInterestDto;
 import com.sprint.team2.monew.domain.interest.dto.response.InterestQueryDto;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.util.UUID;
 
 public interface InterestRepositoryCustom {
-    Page<InterestQueryDto> findAllPage(CursorPageRequestInterestDto request, UUID userId);
+    Slice<InterestQueryDto> findAllPage(CursorPageRequestInterestDto request, UUID userId);
+    Long countTotalElements(String keyword);
+
 }

--- a/src/main/java/com/sprint/team2/monew/domain/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/repository/InterestRepositoryImpl.java
@@ -10,10 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sprint.team2.monew.domain.interest.dto.request.CursorPageRequestInterestDto;
 import com.sprint.team2.monew.domain.interest.dto.response.InterestQueryDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
@@ -30,7 +27,16 @@ import static com.sprint.team2.monew.domain.subscription.entity.QSubscription.su
 public class InterestRepositoryImpl implements InterestRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
-    public Page<InterestQueryDto> findAllPage(CursorPageRequestInterestDto request, UUID userId) {
+    public Long countTotalElements(String keyword) {
+        Long totalElements = jpaQueryFactory.select(interest.count())
+                .from(interest)
+                .where(partialMatch(keyword))
+                .fetchFirst();
+
+        return totalElements;
+    }
+
+    public Slice<InterestQueryDto> findAllPage(CursorPageRequestInterestDto request, UUID userId) {
         OrderSpecifier[] orderSpecifiers = createOrderSpecifier(request.orderBy(), request.direction());
 
         JPAQuery query = jpaQueryFactory
@@ -49,19 +55,20 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
                 .leftJoin(subscription).on(subscription.interest.id.eq(interest.id))
                 .where(partialMatch(request.keyword()))
                 .orderBy(orderSpecifiers)
-                .limit(request.limit());
+                .limit(request.limit()+1);
 
         if (StringUtils.hasText(request.cursor())) {
             query.where(createCursorAfter(request.orderBy(), request.direction(), request.cursor(), request.after()));
         }
+
         List<InterestQueryDto> content = query.fetch();
 
-        Long totalElements = jpaQueryFactory.select(interest.count())
-                .from(interest)
-                .where(partialMatch(request.keyword()))
-                .fetchFirst();
+        boolean hasNext = content!=null && content.size() > request.limit();
+        if (hasNext) {
+            content = content.subList(0, request.limit());
+        }
 
-        return new PageImpl<>(content, PageRequest.of(0,request.limit(), Sort.Direction.valueOf(request.direction()),request.orderBy()), totalElements);
+        return new SliceImpl<>(content, PageRequest.of(0,request.limit(), Sort.Direction.valueOf(request.direction().toUpperCase()),request.orderBy()),hasNext);
     }
 
     private OrderSpecifier[] createOrderSpecifier(String orderBy, String direction) {
@@ -125,8 +132,9 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
 
         predicate.or(interest.name.containsIgnoreCase(keyword));
         predicate.or(Expressions.stringTemplate(
-                "array_to_string({0}, ',')", interest.keywords
-        ).containsIgnoreCase(keyword));
+                        "lower(cast({0} as string))", interest.keywords)
+                .like("%" + keyword.toLowerCase() + "%"
+                ));
         return predicate;
     }
 }

--- a/src/main/java/com/sprint/team2/monew/domain/interest/service/basic/BasicInterestService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/interest/service/basic/BasicInterestService.java
@@ -24,6 +24,7 @@ import com.sprint.team2.monew.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,22 +45,28 @@ public class BasicInterestService implements InterestService {
     @Override
     public CursorPageResponseInterestDto readAll(CursorPageRequestInterestDto pageRequestDto, UUID userId) {
         log.info("[관심사] 목록 조회 실행 userId = {}", userId);
-        Page<InterestQueryDto> pageQuery = interestRepository.findAllPage(pageRequestDto, userId);
+        Slice<InterestQueryDto> pageQuery = interestRepository.findAllPage(pageRequestDto, userId);
+
         if (pageQuery.getContent().isEmpty()) {
             return CursorPageResponseInterestDto.from(Page.empty(),null,null);
         }
+
         InterestQueryDto lastDto = pageQuery.getContent().get(pageQuery.getContent().size() - 1);
         String lastItemCursor = null;
+
         if ("name".equalsIgnoreCase(pageRequestDto.orderBy())){
             lastItemCursor = lastDto.name();
         } else {
             lastItemCursor = String.valueOf(lastDto.subscriberCount());
         }
+
         LocalDateTime lastItemAfter = lastDto.createdAt();
-        Page<InterestDto> page = pageQuery.map(interestMapper::toDto);
-        CursorPageResponseInterestDto response = CursorPageResponseInterestDto.from(page,lastItemAfter,lastItemCursor);
+        Slice<InterestDto> page = pageQuery.map(interestMapper::toDto);
+        Long totalElements = interestRepository.countTotalElements(pageRequestDto.keyword());
+        CursorPageResponseInterestDto response = CursorPageResponseInterestDto.from(page,lastItemCursor,lastItemAfter,totalElements);
         log.info("[관심사] 목록 조회 완료 userId = {}, 검색어 = {}, 결과수 = {}",userId, pageRequestDto.keyword(),response.content().size());
         log.debug("[관심사] 목록 조회 완료 cursor = {}, after = {}", lastItemCursor, lastItemAfter);
+
         return response;
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE interests
     updated_at         TIMESTAMPTZ          DEFAULT CURRENT_TIMESTAMP,
     name               VARCHAR(50) NOT NULL,
     subscription_count BIGINT,
-    keywords           VARCHAR(20)[]
+    keywords           JSON
 );
 
 CREATE TABLE subscriptions


### PR DESCRIPTION
## PR 제목 규칙
[관심사] (fix/183) 관심사 목록 조회 시 hasNext 동작 변경

## 📌 PR 내용 요약
- 관심사 목록 조회 시 hasNext가 마지막 값임에도 true가 나오던 오류 수정
  - 관심사 목록 조회를 Page에서 Slice로 변경
  - 그에 따라 totalElements를 구하는 메서드를 분기
  - 이 외에 hasNext를 구하기 위해 limit+1 수정
    - 이후 subList로 limit까지 삭제 후 반환

- DB 내 interests 테이블 keyword 타입을 json으로 변경
  - 그에 따라 Interest 필드 어노테이션이 변경되었습니다

## 🔗 관련 이슈
- Closes #183

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
