### PR TITLE
[뉴스 기사] (Fix/198) 불필요한 JPAQueryFactory 삭제로 CI 빌드 오류 해결

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
@@ -18,7 +18,6 @@ import com.sprint.team2.monew.domain.interest.entity.Interest;
 import com.sprint.team2.monew.domain.interest.exception.InterestNotFoundException;
 import com.sprint.team2.monew.domain.interest.repository.InterestRepository;
 import com.sprint.team2.monew.domain.notification.event.InterestArticleRegisteredEvent;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -42,7 +41,6 @@ public class BasicArticleService implements ArticleService {
 
     private final InterestRepository interestRepository;
   
-    private final JPAQueryFactory jpaQueryFactory;
     private final ApplicationEventPublisher applicationEventPublisher;
 
 


### PR DESCRIPTION
## PR 제목 규칙
[도메인] (기능분류/이슈카드번호) PR 내용 한 줄 요약

## 📌 PR 내용 요약
- CI 빌드 시 BasicArticleService에서 JPAQueryFactory 관련 컴파일 오류 발생
- 불필요한 JPAQueryFactory가 import 없이 코드에 존재해서 오류 발생

## 🔗 관련 이슈
- Closes #198 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
