### PR TITLE
[알림] (Fix/220) NotificationRepository JPA 메서드 네이밍 오류 수정

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/team2/monew/domain/notification/repository/NotificationRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
-    Slice<Notification> findAllByUserIdAndIsConfirmedFalseOrderByCreatedAtDesc(
+    Slice<Notification> findAllByUserIdAndConfirmedFalseOrderByCreatedAtDesc(
             UUID userId,
             LocalDateTime nextAfter,
             Pageable pageable);

--- a/src/main/java/com/sprint/team2/monew/domain/notification/service/basic/BasicNotificationsService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/notification/service/basic/BasicNotificationsService.java
@@ -176,7 +176,7 @@ public class BasicNotificationsService implements NotificationService {
                 });
         //Pageable 설정
         Pageable pageableRequest = PageRequest.of(0, size, Sort.by("createdAt").descending());
-        Slice<Notification> slice = notificationRepository.findAllByUserIdAndIsConfirmedFalseOrderByCreatedAtDesc(userId, nextAfter, pageableRequest);
+        Slice<Notification> slice = notificationRepository.findAllByUserIdAndConfirmedFalseOrderByCreatedAtDesc(userId, nextAfter, pageableRequest);
 
         List<Notification> notifications = slice.getContent();
 

--- a/src/test/java/com/sprint/team2/monew/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/notification/service/NotificationServiceTest.java
@@ -196,14 +196,14 @@ public class NotificationServiceTest {
             List<Notification> notifications = List.of(n1, n2);
             Slice<Notification> slice = new SliceImpl<>(notifications, pageable, false);
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(notificationRepository.findAllByUserIdAndIsConfirmedFalseOrderByCreatedAtDesc(userId, now, pageable))
+            given(notificationRepository.findAllByUserIdAndConfirmedFalseOrderByCreatedAtDesc(userId, now, pageable))
                     .willReturn(slice);
 
             // when
             notificationService.getAllNotifications(userId,now, size);
 
             // then
-            verify(notificationRepository).findAllByUserIdAndIsConfirmedFalseOrderByCreatedAtDesc(userId, now, pageable);
+            verify(notificationRepository).findAllByUserIdAndConfirmedFalseOrderByCreatedAtDesc(userId, now, pageable);
         }
 
         @Test
@@ -217,7 +217,7 @@ public class NotificationServiceTest {
             LocalDateTime now = LocalDateTime.now();
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(notificationRepository.findAllByUserIdAndIsConfirmedFalseOrderByCreatedAtDesc(userId, now, pageable))
+            given(notificationRepository.findAllByUserIdAndConfirmedFalseOrderByCreatedAtDesc(userId, now, pageable))
                     .willReturn(new SliceImpl<>(List.of(),pageable, false));
 
             // when


### PR DESCRIPTION
## 📌 PR 내용 요약
-findAllByUserIdAndIsConfirmedFalseOrderByCreatedAtDesc -> findAllByUserIdAndConfirmedFalseOrderByCreatedAtDesc
- 수정 후 정상 동작 확인

## 🔗 관련 이슈
- Closes #220 


## 🙋 리뷰어에게 요청사항
- 
