### PR TITLE
[CI/CD] (fix/232) CI 환경에서 스프링 컨텍스트 로드에 실패하는 문제 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET : ${{ secrets.AWS_S3_BUCKET  }}
-        run: ./gradlew clean build
+        run: ./gradlew clean build -Dspring.profiles.active=test
 
       # main 브랜치에 merge할때 뜸
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## 📌 PR 내용 요약
- `ci.yml`에 `test` 프로필로 실행하도록 `run` 코드 수정 
  ```yaml
   run: ./gradlew clean build -Dspring.profiles.active=test
  ```

## 🔗 관련 이슈
- Closes #232
 
## 🙋 리뷰어에게 요청사항

