### PR TITLE
[CI/CD] (Fix/232) CI 스프링 컨텍스트 로드 실패 문제 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,20 @@ jobs:
       - name: 테스트 권한 부여
         run: chmod +x ./gradlew
 
-      - name: 빌드와 테스트
+      # 4. 빌드 (테스트 제외, dev 환경 그대로 빌드)
+      - name: Build (skip tests)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          AWS_S3_BUCKET : ${{ secrets.AWS_S3_BUCKET  }}
-        run: ./gradlew clean build -Dspring.profiles.active=test
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: ./gradlew clean build -x test -Dspring.profiles.active=dev
+
+      # 5. 테스트 (test 프로필 강제 + H2 사용)
+      - name: Run integration tests with H2
+        env:
+          SPRING_PROFILES_ACTIVE: test
+        run: ./gradlew test -Dspring.profiles.active=test --info --stacktrace
 
       # main 브랜치에 merge할때 뜸
       - name: Upload coverage reports to Codecov

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,9 +6,9 @@ spring:
 #    url: ${SPRING_DATASOURCE_URL}
 #    username: ${SPRING_DATASOURCE_USERNAME}
 #    password: ${SPRING_DATASOURCE_PASSWORD}
-    url: ${POSTGRESQL_DATASOURCE_URL}
-    username: ${POSTGRESQL_DATASOURCE_USERNAME}
-    password: ${POSTGRESQL_DATASOURCE_PASSWORD}
+    url: ${POSTGRESQL_DATASOURCE_URL:}
+    username: ${POSTGRESQL_DATASOURCE_USERNAME:}
+    password: ${POSTGRESQL_DATASOURCE_PASSWORD:}
   jpa:
     properties:
       hibernate:

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -13,10 +13,14 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        database-platform: org.hibernate.dialect.H2Dialect
         format_sql: true
+  batch:
+    jdbc:
+      initialize-schema: always
 
 logging:
   level:
-    com.sprint.mission.discodeit: debug
+    com.sprint.team2.monew: debug
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
## 📌 PR 내용 요약
- 보다 자세한 CI 에러 로그를 확인해보니, 빌드 과정에서 `dev` 프로필로 구동하여 `${POSTGRESQL_DATASOURCE_URL}` 환경 변수를 찾지 못해 DB 연동에 실패하는 것을 확인함
- DB 연동 실패 -> Spring Context 로드 실패 -> `@SpringBootTest`를 사용하는 통합 테스트 실패로 이어짐
  - `dev` 프로필의 db 환경 설정에 디폴트 값으로 빈 문자열 추가
  - `ci.yml` 파일 수정: 빌드와 테스트를 분리하여 각각 다른 환경을 적용하도록 명시 

## 🔗 관련 이슈
- Closes #232 

## 🙋 리뷰어에게 요청사항
