### PR TITLE
[뉴스 기사] (Fix/251) 커서페이지네이션 오류 해결 및 검색 키워드 변경 후 조회 이상 오류 해결

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
@@ -196,7 +196,11 @@ public class BasicArticleService implements ArticleService {
                                              LocalDateTime after) {
 
         log.info("[Article] 뉴스 기사 목록 조회 시작");
-        limit = 50;
+        if (keyword == null || keyword.isBlank() || cursor == null && after == null) {
+            cursor = null;
+            after = null;
+            limit = 50;
+        }
 
         if (orderBy != ArticleOrderBy.publishDate &&
                 orderBy != ArticleOrderBy.commentCount &&

--- a/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
@@ -183,15 +183,20 @@ public class BasicArticleService implements ArticleService {
 
     @Override
     @Transactional(readOnly = true)
-    public CursorPageResponseArticleDto read(UUID userId, ArticleOrderBy orderBy, ArticleDirection direction, int limit,
+    public CursorPageResponseArticleDto read(UUID userId,
+                                             ArticleOrderBy orderBy,
+                                             ArticleDirection direction,
+                                             int limit,
                                              String keyword,
-                                             UUID interestId, List<ArticleSource> sourceIn, LocalDateTime publishedDateFrom, LocalDateTime publishedDateTo,
-                                             String cursor, LocalDateTime after) {
+                                             UUID interestId,
+                                             List<ArticleSource> sourceIn,
+                                             LocalDateTime publishedDateFrom,
+                                             LocalDateTime publishedDateTo,
+                                             String cursor,
+                                             LocalDateTime after) {
 
-        if (limit <= 0) {
-            log.error("[Article] 커서 페이지 크기는 0보다 커야 함, limit = {}", limit);
-            throw InvalidParameterException.invalidParameter();
-        }
+        log.info("[Article] 뉴스 기사 목록 조회 시작");
+        limit = 50;
 
         if (orderBy != ArticleOrderBy.publishDate &&
                 orderBy != ArticleOrderBy.commentCount &&
@@ -202,43 +207,47 @@ public class BasicArticleService implements ArticleService {
 
         List<Article> articles = articleRepositoryCustom.searchArticles(
                 keyword, interestId, sourceIn, publishedDateFrom, publishedDateTo,
-                orderBy, direction,
-                cursor, after, limit
+                orderBy, direction, cursor, after, limit
         );
 
         boolean hasNext = articles.size() > limit;
-        if (hasNext) {
-            articles = articles.subList(0, limit);
-        }
-
-        log.debug("[Article] 조회한 결과 조회, userId = {}, keyword = {}, interestId = {}, size = {}, hasNext = {}, nextCursor = {}",
-                userId, keyword, interestId, articles.size(), hasNext,
-                !articles.isEmpty() ? (orderBy == ArticleOrderBy.publishDate ? articles.get(articles.size() - 1).getPublishDate() : articles.get(articles.size() - 1).getCommentCount()) : null);
 
         String nextCursor = null;
         LocalDateTime nextAfter = null;
 
-        if (!articles.isEmpty()) {
-            Article last = articles.get(articles.size() - 1);
-            switch (orderBy) {
-                case commentCount -> nextCursor = String.valueOf(last.getCommentCount());
-                case viewCount -> nextCursor = String.valueOf(last.getViewCount());
-                default -> nextCursor = last.getPublishDate().toString();
-            }
+        if (hasNext) {
+            Article last = articles.get(limit);
 
-            nextAfter = last.getCreatedAt();
+            switch (orderBy) {
+                case commentCount -> {
+                    nextCursor = String.valueOf(last.getCommentCount());
+                    nextAfter = last.getCreatedAt();
+
+                }
+                case viewCount -> {
+                    nextCursor = String.valueOf(last.getViewCount());
+                    nextAfter = last.getCreatedAt();
+                }
+                default -> {
+                    nextAfter = last.getCreatedAt();
+                    nextCursor = last.getPublishDate().toString();
+                }
+            }
+            articles = articles.subList(0, limit);
         }
 
-        long totalElements = articleRepositoryCustom.countArticles(
-                keyword, interestId, sourceIn, publishedDateFrom, publishedDateTo
-        );
+        List<ArticleDto> content = articles.stream()
+                .map(articleMapper::toArticleDto)
+                .toList();
+
+        log.info("[Article] 뉴스 기사 목록 조회 성공");
 
         return new CursorPageResponseArticleDto(
-                articles.stream().map(articleMapper::toArticleDto).toList(),
+                content,
                 nextCursor,
                 nextAfter,
-                articles.size(),
-                totalElements,
+                content.size(),
+                articleRepositoryCustom.countArticles(keyword, interestId, sourceIn, publishedDateFrom, publishedDateTo),
                 hasNext
         );
     }

--- a/src/main/java/com/sprint/team2/monew/global/config/WebConfig.java
+++ b/src/main/java/com/sprint/team2/monew/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.sprint.team2.monew.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -9,6 +10,9 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,5 +42,20 @@ public class WebConfig implements WebMvcConfigurer {
         );
       }
     }
+  }
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(String.class, LocalDateTime.class, source -> {
+      if (source == null || source.isEmpty()) return null;
+
+      if (source.endsWith("Z")) {
+        return OffsetDateTime.parse(source)
+                .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                .toLocalDateTime();
+      } else {
+        return LocalDateTime.parse(source);
+      }
+    });
   }
 }

--- a/src/main/java/com/sprint/team2/monew/global/config/WebConfig.java
+++ b/src/main/java/com/sprint/team2/monew/global/config/WebConfig.java
@@ -19,43 +19,44 @@ import java.util.List;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-  private final MDCLoggingInterceptor mdcLoggingInterceptor;
+    private final MDCLoggingInterceptor mdcLoggingInterceptor;
 
-  @Override
-  public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(mdcLoggingInterceptor)
-            .addPathPatterns("/**"); // 모든 요청에 적용
-  }
-  @Override
-  public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-    for (HttpMessageConverter<?> converter : converters) {
-      // JSON 변환기만 찾아서
-      if (converter instanceof MappingJackson2HttpMessageConverter) {
-        MappingJackson2HttpMessageConverter jsonConverter = (MappingJackson2HttpMessageConverter) converter;
-
-        // 기본 문자셋을 UTF-8로 설정
-        jsonConverter.setDefaultCharset(StandardCharsets.UTF_8);
-
-        // 지원하는 미디어 타입에 charset=UTF-8 명시
-        jsonConverter.setSupportedMediaTypes(
-            Collections.singletonList(new MediaType("application", "json", StandardCharsets.UTF_8))
-        );
-      }
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(mdcLoggingInterceptor)
+                .addPathPatterns("/**"); // 모든 요청에 적용
     }
-  }
 
-  @Override
-  public void addFormatters(FormatterRegistry registry) {
-    registry.addConverter(String.class, LocalDateTime.class, source -> {
-      if (source == null || source.isEmpty()) return null;
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        for (HttpMessageConverter<?> converter : converters) {
+            // JSON 변환기만 찾아서
+            if (converter instanceof MappingJackson2HttpMessageConverter) {
+                MappingJackson2HttpMessageConverter jsonConverter = (MappingJackson2HttpMessageConverter) converter;
 
-      if (source.endsWith("Z")) {
-        return OffsetDateTime.parse(source)
-                .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
-                .toLocalDateTime();
-      } else {
-        return LocalDateTime.parse(source);
-      }
-    });
-  }
+                // 기본 문자셋을 UTF-8로 설정
+                jsonConverter.setDefaultCharset(StandardCharsets.UTF_8);
+
+                // 지원하는 미디어 타입에 charset=UTF-8 명시
+                jsonConverter.setSupportedMediaTypes(
+                        Collections.singletonList(new MediaType("application", "json", StandardCharsets.UTF_8))
+                );
+            }
+        }
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(String.class, LocalDateTime.class, source -> {
+            if (source == null || source.isEmpty()) return null;
+
+            if (source.endsWith("Z")) {
+                return OffsetDateTime.parse(source)
+                        .atZoneSameInstant(ZoneId.of("Asia/Seoul"))
+                        .toLocalDateTime();
+            } else {
+                return LocalDateTime.parse(source);
+            }
+        });
+    }
 }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] (기능분류/이슈카드번호) PR 내용 한 줄 요약

## 📌 PR 내용 요약
- hasNext가 true임에도 다음 데이터를 못 가지고 오는 오류 해결
   - FE에서 Z포함 문자열로 들어오는데 BE는 LocalDateTime을 사용해서 after를 제대로 찾지 못해 오류뜸
   - webConfig에 Z포함 문자열로 들어오는 것을 LocalDateTime으로 들어오도록 수정
- 키워드 변경 후 조회된 데이터를 제대로 못 가지고 오는 오류 해결
   - limit을 50(default)으로 고정

## 🔗 관련 이슈
- Closes #251 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 시간에 타임존 들어오던게 FE에서 들어오는 것이길래, 아예 LocalDateTime으로 들어올 수 있도록 global 처리했습니다!
