### PR TITLE
[CI/CD] (Fix/232) S3Client 모킹 클래스 추가

### DIFF
--- a/src/test/java/com/sprint/team2/monew/global/config/aws/DummyAwsConfig.java
+++ b/src/test/java/com/sprint/team2/monew/global/config/aws/DummyAwsConfig.java
@@ -1,0 +1,17 @@
+package com.sprint.team2.monew.global.config.aws;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@TestConfiguration
+@Profile("test")
+public class DummyAwsConfig {
+
+    @Bean
+    public S3Client s3Client() {
+        // 더미 객체 주입
+        return org.mockito.Mockito.mock(S3Client.class);
+    }
+}


### PR DESCRIPTION
## 📌 PR 내용 요약
- 더미데이터로 `AwsConfig` 실행 시 CI 테스트 환경에서 오류가 발생하여 테스트용 `s3Client` 모킹 클래스인 `DummyAwsConfig`을 `test.com.sprint.team2.monew.global.config.aws`에 추가하였습니다. (테스트 패키지 내에 추가)


## 🔗 관련 이슈
- Closes #232 

## 🙋 리뷰어에게 요청사항
