### PR TITLE
[활동 내역] (Fix/263) TransactionalEventListener 추가

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/entity/UserActivity.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/entity/UserActivity.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @Document
 public class UserActivity {
 
@@ -34,7 +33,15 @@ public class UserActivity {
   private List<CommentActivityLikeDto> commentLikes = new ArrayList<>();
   private List<ArticleViewDto> articleViews = new ArrayList<>();
 
+  public UserActivity() {
+    this.subscriptions = new ArrayList<>();
+    this.comments = new ArrayList<>();
+    this.commentLikes = new ArrayList<>();
+    this.articleViews = new ArrayList<>();
+  }
+
   public UserActivity(UUID id, String email, String nickname) {
+    this();
     this.id = id;
     this.email = email;
     this.nickname = nickname;

--- a/src/main/java/com/sprint/team2/monew/domain/userActivity/listener/UserActivityListener.java
+++ b/src/main/java/com/sprint/team2/monew/domain/userActivity/listener/UserActivityListener.java
@@ -29,6 +29,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -45,7 +46,7 @@ public class UserActivityListener {
 
   // ================================== 사용자 ==================================
   // 사용자 생성
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleUserCreate(UserCreateEvent event) {
     UUID id = event.id();
@@ -63,7 +64,7 @@ public class UserActivityListener {
     log.info("[사용자 활동] 생성 완료 - id = {}", id);
   }
 
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleUserLogin(UserLoginEvent event) {
     UUID id = event.id();
@@ -86,7 +87,7 @@ public class UserActivityListener {
   }
 
   // 사용자 닉네임 수정
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleUserUpdate(UserUpdateEvent event) {
 
@@ -104,7 +105,7 @@ public class UserActivityListener {
   }
 
   // 사용자 삭제
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleUserDelete(UserDeleteEvent event) {
 
@@ -118,7 +119,7 @@ public class UserActivityListener {
 
   // ================================== 구독 ==================================
   // 구독 업데이트
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleSubscriptionAdd(SubscriptionAddEvent event) {
     UUID userId = event.userId();
@@ -146,7 +147,7 @@ public class UserActivityListener {
   }
 
   // 구독 업데이트
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleSubscriptionCancel(SubscriptionCancelEvent event) {
     UUID userId = event.userId();
@@ -166,7 +167,7 @@ public class UserActivityListener {
   }
 
   // 관심사가 삭제되었을 때, 유저가 구독했으면 삭제
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleSubscriptionDelete(SubscriptionDeleteEvent event) {
     UUID interestId = event.interestId();
@@ -189,7 +190,7 @@ public class UserActivityListener {
 
   // ================================== 댓글 (최신 10개) ==================================
   // 유저 댓글 추가
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleCommentAdd(CommentAddEvent event) {
     UUID commentId = event.id();
@@ -213,7 +214,7 @@ public class UserActivityListener {
     log.info("[사용자 활동] 댓글 추가 완료- commentId = {}", commentId);
   }
 
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleCommentUpdate(CommentUpdateEvent event) {
     UUID commentId = event.id();
@@ -243,7 +244,7 @@ public class UserActivityListener {
   }
 
   // 유저 댓글 삭제
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleCommentDelete(CommentDeleteEvent event) {
     UUID userId = event.userId();
@@ -265,7 +266,7 @@ public class UserActivityListener {
   // ================================== 댓글 좋아요 (최신 10개) ==================================
 
   // 유저 댓글 좋아요
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleCommentLikeAdd(CommentLikeAddEvent event) {
     UUID commentId = event.commentId();
@@ -294,7 +295,7 @@ public class UserActivityListener {
   }
 
   // 유저 댓글 좋아요 취소
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleCommentLikeCancel(CommentLikeCancelEvent event) {
     UUID commentId = event.id();
@@ -317,7 +318,7 @@ public class UserActivityListener {
   // ================================== 읽은 기사 (최신 10개) ==================================
 
   // 유저가 최근에 읽은 기사
-  @EventListener
+  @TransactionalEventListener
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void handleArticleViewAdd(ArticleViewEvent event) {
     UUID userId = event.getId();


### PR DESCRIPTION
## PR 제목 규칙
[활동 내역] (Fix/263) TransactionalEventListener 추가

## 📌 PR 내용 요약
- TransactionalEventListener 추가
  - 활동 내역 페이지에 들어가면 화면 먹통 되는 버그 원인 추측: 리스너를 호출하는 메서드가 완전히 끝나지 않고 호출이 되어서 저장이 안된다고 가정해서 @TransactionalEventListener로 변경
- 생성자 수정

## 🔗 관련 이슈
- Closes #263 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
