### PR TITLE
[CI/CD] (Fix/232) AwsConfig 클래스를 테스트 환경에서 불러오지 않게 어노테이션 추가

### DIFF
--- a/src/main/java/com/sprint/team2/monew/global/config/aws/AwsConfig.java
+++ b/src/main/java/com/sprint/team2/monew/global/config/aws/AwsConfig.java
@@ -3,13 +3,12 @@ package com.sprint.team2.monew.global.config.aws;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 @EnableConfigurationProperties(S3Properties.class)
+@Profile("!test")
 public class AwsConfig {
 
   /**


### PR DESCRIPTION
## 📌 PR 내용 요약
- AwsConfig 클래스를 테스트 환경에서 불러오지 않게 어노테이션 추가

## 🔗 관련 이슈
- Closes #232 

## 🙋 리뷰어에게 요청사항
- 
