### PR TITLE
[CI/CD] (Fix/232) ci run 옵션에서 스택트레이스 속성 삭제

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run integration tests with H2
         env:
           SPRING_PROFILES_ACTIVE: test
-        run: ./gradlew test -Dspring.profiles.active=test --info --stacktrace
+        run: ./gradlew test -Dspring.profiles.active=test
 
       # main 브랜치에 merge할때 뜸
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## 📌 PR 내용 요약
-  ci run 옵션에서 스택트레이스 속성을 삭제하였습니다. 

## 🔗 관련 이슈
- Closes #232 

## 🙋 리뷰어에게 요청사항
- 
