### PR TITLE
[뉴스 기사] (Fix/283) 뉴스 기사 조회할 때 댓글 수 제대로 안보이는 버그 해결

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
@@ -20,7 +20,6 @@ import com.sprint.team2.monew.domain.comment.repository.CommentRepository;
 import com.sprint.team2.monew.domain.interest.entity.Interest;
 import com.sprint.team2.monew.domain.interest.exception.InterestNotFoundException;
 import com.sprint.team2.monew.domain.interest.repository.InterestRepository;
-import com.sprint.team2.monew.domain.user.entity.User;
 import com.sprint.team2.monew.domain.user.exception.UserNotFoundException;
 import com.sprint.team2.monew.domain.user.repository.UserRepository;
 import com.sprint.team2.monew.domain.userActivity.entity.UserActivity;
@@ -36,7 +35,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -113,7 +111,7 @@ public class BasicArticleService implements ArticleService {
                     return ArticleNotFoundException.withId(articleId);
                 });
 
-        User user = userRepository.findById(userId)
+        userRepository.findById(userId)
                 .orElseThrow(() -> {
                     log.error("[User] 존재하지 않는 사용자, userId = {}", userId);
                     return UserNotFoundException.withId(userId);


### PR DESCRIPTION
## PR 제목 규칙
[도메인] (기능분류/이슈카드번호) PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 뉴스 기사 조회할 때 댓글 수 제대로 안보이는 문제 해결
- 공통 메서드로 viewedByMe 볼 수 있게 함
- userActivity Entity 수정되면서 필요없어진 코드 정리

## 🔗 관련 이슈
- Closes #283 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
