### PR TITLE
[알림] (Fix/320) 좋아요 관련 이벤트 발행 코드 수정

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/like/service/basic/BasicReactionService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/like/service/basic/BasicReactionService.java
@@ -72,7 +72,7 @@ public class BasicReactionService implements ReactionService {
             // 좋아요 생성 시 알림 이벤트 발행
             applicationEventPublisher.publishEvent(new CommentLikedEvent(
                     commentId,
-                    user.getId()
+                    comment.getUser().getId()
             ));
 
             //원자적 +1 (동시성 안전)


### PR DESCRIPTION
## 📌 PR 내용 요약
- 알림 좋아요 시 댓글 작성자가 아닌 좋아요 누른 사용자에게 알림 생성되는 문제 발생
- BasicReactionService의 이벤트 발행코드에서 해당 이벤트의 ReceiverId가 댓글을 작성한 사람이 되도록 코드 수정

## 🔗 관련 이슈
- Closes #320 

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/b3765b29-5660-47bc-b430-1cc83fdefe9f" />
➡️ 문제 상황 화면 캡쳐

## 🙋 리뷰어에게 요청사항
- 
