### PR TITLE
[알림] (Fix/315) 알림 확인 시 필드명 불일치로 인한 문제

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/sprint/team2/monew/domain/notification/dto/response/NotificationDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record NotificationDto(
-    UUID notificationId,
+    UUID id,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
     boolean confirmed,

--- a/src/main/java/com/sprint/team2/monew/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/sprint/team2/monew/domain/notification/mapper/NotificationMapper.java
@@ -9,6 +9,5 @@ import org.mapstruct.Mapping;
 public interface NotificationMapper {
 
     @Mapping(source = "user.id", target = "userId")
-    @Mapping(source = "id", target = "notificationId")
     NotificationDto toNotificationDto(Notification entity);
 }

--- a/src/test/java/com/sprint/team2/monew/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/notification/service/NotificationServiceTest.java
@@ -128,14 +128,16 @@ public class NotificationServiceTest {
             Reaction like = TestLikeFactory.createLike();
             Comment comment = TestCommentFactory.createComment();
             User receiver = like.getComment().getUser();
+            User likedUser = like.getUser();
 
             UUID receiverId = receiver.getId();
             UUID commentId = like.getComment().getId();
+            UUID likedUserId = likedUser.getId();
 
             given(userRepository.findById(receiverId)).willReturn(Optional.of(receiver));
             given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
 
-            CommentLikedEvent event = new CommentLikedEvent(commentId, receiverId);
+            CommentLikedEvent event = new CommentLikedEvent(commentId, receiverId, likedUserId);
 
             //알림 객체 생성
             Notification notification = Notification.builder()
@@ -160,11 +162,13 @@ public class NotificationServiceTest {
         void shouldThrowWhenReceiverDoesNotExist() {
             // given
             Comment comment = TestCommentFactory.createComment();
+            User likedUser = TestUserFactory.createUser();
 
             UUID commentId = comment.getId();
+            UUID likedUserId = likedUser.getId();
             UUID nonExistentUserId = UUID.randomUUID();
 
-            CommentLikedEvent event = new CommentLikedEvent(commentId, nonExistentUserId);
+            CommentLikedEvent event = new CommentLikedEvent(commentId, nonExistentUserId, likedUserId);
 
             given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
             given(userRepository.findById(nonExistentUserId)).willReturn(Optional.empty());


### PR DESCRIPTION
## 📌 PR 내용 요약
- 프론트 소스 코드 확인 후 NotificationDto의 필드와 일치하지 않는 필드명 수정

## 🔗 관련 이슈
- Closes #315 

## 🙋 리뷰어에게 요청사항
- 
