### PR TITLE
[알림] (Fix/349) 확인하지 않은 알림 개수 계산 로직 수정

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/team2/monew/domain/notification/repository/NotificationRepository.java
@@ -32,7 +32,7 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
 
     List<Notification> findAllByConfirmedIsTrueAndUpdatedAtBefore(LocalDateTime threshold);
 
-    Long countByUserId(UUID userId);
+    Long countByUserIdAndConfirmedFalse(UUID userId);
 
     void deleteByResourceTypeAndResourceId(ResourceType resourceType, UUID resourceId);
 }

--- a/src/main/java/com/sprint/team2/monew/domain/notification/service/basic/BasicNotificationsService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/notification/service/basic/BasicNotificationsService.java
@@ -199,7 +199,7 @@ public class BasicNotificationsService implements NotificationService {
             nextCursor = notifications.get(notifications.size() - 1).getCreatedAt().toString();
         }
 
-        Long totalElements = notificationRepository.countByUserId((userId));
+        Long totalElements = notificationRepository.countByUserIdAndConfirmedFalse(userId);
 
         log.info("[알림] 응답 생성 완료 - contentSize={}, totalElements={}, hasNext={}",
                 content.size(), totalElements, slice.hasNext());


### PR DESCRIPTION
## 📌 PR 내용 요약
- totalElements 를 계산하는 로직 중 확인, 미확인 관계 없이 모든 알림의 개수를 세고 있어 화면상 종모양 아이콘 위에 알림의 개수가 줄어들지 않는 문제 발생
  - repository 메서드 변경, service 코드 변경

 
## 🔗 관련 이슈
- Closes #349 

## 🙋 리뷰어에게 요청사항
- 
