### PR TITLE
[댓글](fix/360) 댓글 삭제 시 전체 댓글 수에 변화가 없는 오류 해결

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleService.java
@@ -141,7 +141,7 @@ public class BasicArticleService implements ArticleService {
             viewedDate = userActivityRepositoryCustom.findByArticleId(userId ,articleId).createdAt();
         }
 
-        articleCommentCount = commentRepository.countByArticle_Id(articleId);
+        articleCommentCount = commentRepository.countByArticle_IdAndNotDeleted(articleId);
 
         log.info("[Article] 기사 뷰 등록 성공");
         ArticleViewDto articleViewDto = new ArticleViewDto(
@@ -231,7 +231,7 @@ public class BasicArticleService implements ArticleService {
                         article.getTitle(),
                         article.getPublishDate(),
                         article.getSummary(),
-                        commentRepository.countByArticle_Id(article.getId()),
+                        commentRepository.countByArticle_IdAndNotDeleted(article.getId()),
                         article.getViewCount(),
                         hasUserViewedArticle(userId, article.getId())
                 ))

--- a/src/main/java/com/sprint/team2/monew/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/team2/monew/domain/comment/repository/CommentRepository.java
@@ -113,5 +113,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
            """)
     int softDeleteById(@Param("id") UUID id);
 
-    long countByArticle_Id(UUID articleId);
+//    하드 삭제 후 전체 댓글 수 조회용 메서드
+//    long countByArticle_Id(UUID articleId);
 }

--- a/src/test/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleServiceTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/article/service/basic/BasicArticleServiceTest.java
@@ -170,7 +170,7 @@ class BasicArticleServiceTest {
         when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(userActivityRepository.findById(userId)).thenReturn(Optional.of(userActivity));
-        when(commentRepository.countByArticle_Id(articleId)).thenReturn(0L);
+        when(commentRepository.countByArticle_IdAndNotDeleted(articleId)).thenReturn(0L);
 
         // when
         ArticleViewDto result = basicArticleService.view(userId, articleId);

--- a/src/test/java/com/sprint/team2/monew/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/team2/monew/domain/comment/repository/CommentRepositoryTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -96,11 +97,15 @@ public class CommentRepositoryTest {
     @Test
     @DisplayName("incrementLikeCount: like_count 1 증가 & 조회로 검증")
     void incrementLikeCountUpdatesAndReads() {
+        //given
         Comment c = persistAndReturn(newComment("hello", 0));
+
+        //when
         int updated = commentRepository.incrementLikeCount(c.getId());
         tem.flush(); tem.clear();
-
         Long like = commentRepository.findLikeCountById(c.getId());
+
+        //then
         assertThat(updated).isEqualTo(1);
         assertThat(like).isEqualTo(1L);
     }
@@ -108,18 +113,20 @@ public class CommentRepositoryTest {
     @Test
     @DisplayName("decrementLikeCount: 0에서 감소해도 음수로 내려가지 않음")
     void decrementLikeCountNotBelowZero() {
+        //given
         Comment c0 = persistAndReturn(newComment("zero", 0));
+        Comment c2 = persistAndReturn(newComment("two", 2));
+
+        //when
         int u1 = commentRepository.decrementLikeCount(c0.getId());
         tem.flush(); tem.clear();
-
-        Long like0 = commentRepository.findLikeCountById(c0.getId());
-        assertThat(u1).isEqualTo(1);
-        assertThat(like0).isEqualTo(0L);
-
-        Comment c2 = persistAndReturn(newComment("two", 2));
         int u2 = commentRepository.decrementLikeCount(c2.getId());
         tem.flush(); tem.clear();
 
+        //then
+        Long like0 = commentRepository.findLikeCountById(c0.getId());
+        assertThat(u1).isEqualTo(1);
+        assertThat(like0).isEqualTo(0L);
         Long like1 = commentRepository.findLikeCountById(c2.getId());
         assertThat(u2).isEqualTo(1);
         assertThat(like1).isEqualTo(1L);
@@ -128,9 +135,13 @@ public class CommentRepositoryTest {
     @Test
     @DisplayName("findWithArticleAndUserById: fetch join으로 연관엔티티 로딩")
     void findWithArticleAndUserByIdFetches() {
+        //given
         Comment c = persistAndReturn(newComment("fetch", 0));
 
-        var loaded = commentRepository.findWithArticleAndUserById(c.getId());
+        //when
+        Optional<Comment> loaded = commentRepository.findWithArticleAndUserById(c.getId());
+
+        //then
         assertThat(loaded).isPresent();
         assertThat(loaded.get().getArticle()).isNotNull();
         assertThat(loaded.get().getUser()).isNotNull();
@@ -141,22 +152,26 @@ public class CommentRepositoryTest {
     @Test
     @DisplayName("softDeleteById: 삭제 플래그 세팅 & NotDeleted 조회에서 제외")
     void softDeleteByIdMarksDeletedAndFilteredOut() {
+        //given
         Comment c = persistAndReturn(newComment("to delete", 0));
+        long before = commentRepository.countByArticle_IdAndNotDeleted(article.getId());
 
+        //when
         int updated = commentRepository.softDeleteById(c.getId());
         tem.flush(); tem.clear();
 
+        //then
         assertThat(updated).isEqualTo(1);
         assertThat(commentRepository.findByIdAndDeletedAtIsNull(c.getId())).isEmpty();
 
-        long total = commentRepository.countByArticle_Id(article.getId());
-        long notDeleted = commentRepository.countByArticle_IdAndNotDeleted(article.getId());
-        assertThat(total).isGreaterThanOrEqualTo(notDeleted);
+        long after = commentRepository.countByArticle_IdAndNotDeleted(article.getId());
+        assertThat(after).isEqualTo(before - 1);
     }
 
     @Test
     @DisplayName("findByArticle_IdWithDateCursor: 날짜 커서 + ASC 정렬 Slice")
     void findByArticleIdWithDateCursorDateCursorAsc() {
+        //given
         Comment c1 = persistAndReturn(newComment("c1", 0)); smallDelay();
         Comment c2 = persistAndReturn(newComment("c2", 0)); smallDelay();
         Comment c3 = persistAndReturn(newComment("c3", 0)); smallDelay();
@@ -165,6 +180,7 @@ public class CommentRepositoryTest {
 
         // 첫 페이지 (ASC, after/cursor 없음)
         Pageable page2Asc = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "createdAt"));
+        //when(page:1)
         Slice<Comment> slice1 = commentRepository.findByArticle_IdWithDateCursor(
                 article.getId(),
                 false, null,
@@ -172,10 +188,13 @@ public class CommentRepositoryTest {
                 true,
                 page2Asc
         );
+
+        //then(page:1)
         assertThat(slice1.getContent()).hasSize(2);
         LocalDateTime lastCreated = slice1.getContent().get(1).getCreatedAt();
 
         // 다음 페이지: cursorDate = 직전 페이지 마지막 요소의 createdAt
+        //when(page:2)
         Slice<Comment> slice2 = commentRepository.findByArticle_IdWithDateCursor(
                 article.getId(),
                 false, null,
@@ -183,11 +202,14 @@ public class CommentRepositoryTest {
                 true,
                 page2Asc
         );
+
+        //then(page:2)
         assertThat(slice2.getContent()).hasSize(2);
         assertThat(slice2.hasNext()).isTrue(); // 아직 남음(c5)
 
         // 세 번째 페이지
         LocalDateTime last2 = slice2.getContent().get(1).getCreatedAt();
+        //when(page:3)
         Slice<Comment> slice3 = commentRepository.findByArticle_IdWithDateCursor(
                 article.getId(),
                 false, null,
@@ -195,6 +217,7 @@ public class CommentRepositoryTest {
                 true,
                 page2Asc
         );
+        //then(page:3)
         assertThat(slice3.getContent()).hasSize(1);
         assertThat(slice3.hasNext()).isFalse();
     }
@@ -202,6 +225,7 @@ public class CommentRepositoryTest {
     @Test
     @DisplayName("findByArticle_IdWithLikeCountCursor: likeCount 커서 + DESC 정렬 Slice (동점시 createdAt)")
     void findByArticleIdWithLikeCountCursorLikeCursorDesc() {
+        //given
         Comment a = persistAndReturn(newComment("a", 0)); smallDelay();
         Comment b = persistAndReturn(newComment("b", 1)); smallDelay();
         Comment c = persistAndReturn(newComment("c", 1)); smallDelay();
@@ -212,6 +236,7 @@ public class CommentRepositoryTest {
                 Sort.by(Sort.Direction.DESC, "likeCount")
                         .and(Sort.by(Sort.Direction.DESC, "createdAt")));
 
+        //when(page:1)
         // 첫 페이지 (cursor 없음)
         Slice<Comment> s1 = commentRepository.findByArticle_IdWithLikeCountCursor(
                 article.getId(),
@@ -220,11 +245,14 @@ public class CommentRepositoryTest {
                 false,
                 page2Desc
         );
+
+        //then(page:1)
         assertThat(s1.getContent()).hasSize(2);
         long firstLike = s1.getContent().get(0).getLikeCount();
         long secondLike = s1.getContent().get(1).getLikeCount();
         assertThat(firstLike).isGreaterThanOrEqualTo(secondLike);
 
+        //when(page:2)
         // cursor: 직전 페이지 마지막 요소의 (likeCount, createdAt)
         Comment last = s1.getContent().get(1);
         Slice<Comment> s2 = commentRepository.findByArticle_IdWithLikeCountCursor(
@@ -234,6 +262,8 @@ public class CommentRepositoryTest {
                 false,
                 page2Desc
         );
+
+        //then(page:2)
         assertThat(s2.getContent()).hasSize(2);
         // 남은 요소들의 likeCount가 cursor 이하(동점이면 createdAt < cursorDate)인지 대략 검증
         if (!s2.getContent().isEmpty()) {


### PR DESCRIPTION
## PR 제목 규칙
[도메인] (기능분류/이슈카드번호) PR 내용 한 줄 요약

## 📌 PR 내용 요약
- 댓글 삭제 시 표시된 댓글 수에 변화가 없는 오류를 발견하여 수정하였습니다.

## 🔗 관련 이슈
- Closes #360 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
