### PR TITLE
[로그 관리] (Fix/374) 내부적으로 로그 30일 관리로 변경

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
         <file>.logs/myapp.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>.logs/myapp.%d{yy-MM-dd}.log</fileNamePattern>
-            <maxHistory>24</maxHistory>
+            <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
             <pattern>%d{yy}-%d{MM}-%d{dd} %d{HH}:%d{mm}:%d{ss} [%X{requestIP} | %X{requestId} | %X{requestMethod} | %X{requestUrl}] -


### PR DESCRIPTION
## PR 제목 규칙
[로그 관리] (Fix/374) 내부적으로 로그 30일 관리로 변경

## 📌 PR 내용 요약
- 로그를 내부적으로 30일 동안 보관
- 이전에 24일

## 🔗 관련 이슈
- Closes #

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
