### PR TITLE
[뉴스 기사] (Fix/387)  RSS 기사에 discription이 없을 경우 summary가 비어보이는 문제 수정

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/collect/RssCollector.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/collect/RssCollector.java
@@ -58,16 +58,6 @@ public class RssCollector implements Collector {
                             String description = textOrEmpty(item, "description");
                             String contentStr = getTagText(item, "content:encoded");
                             String pubDateStr = textOrEmpty(item, "pubDate");
-
-                            String content = "";
-                            if (!contentStr.isBlank()) {
-                                Document contentDoc = Jsoup.parse(contentStr);
-                                Element element = contentDoc.selectFirst("p");
-                                if (element != null) {
-                                    content = element.text();
-                                }
-                            }
-
                             LocalDateTime publishDate;
                             try {
                                 publishDate = ZonedDateTime.parse(pubDateStr, DateTimeFormatter.RFC_1123_DATE_TIME)
@@ -80,10 +70,13 @@ public class RssCollector implements Collector {
                             String summary;
                             if (!description.isBlank()) {
                                 summary = description;
-                            } else if (!content.isBlank()) {
-                                summary = content;
                             } else {
-                                summary = title;
+                                String content = extractFirstParagragh(contentStr);
+                                if (!content.isBlank()) {
+                                    summary = content;
+                                } else {
+                                    summary = title;
+                                }
                             }
 
                             Article article = Article.builder()
@@ -119,5 +112,14 @@ public class RssCollector implements Collector {
     private static String getTagText(Element item, String tag) {
         Element el = item.getElementsByTag(tag).first();
         return el != null ? el.text() : "";
+    }
+
+    private static String extractFirstParagragh(String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+        Document doc = Jsoup.parse(html);
+        Element element = doc.selectFirst("p");
+        return element != null ? element.text() : "";
     }
 }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] (기능분류/이슈카드번호) PR 내용 한 줄 요약

## 📌 PR 내용 요약
-  RSS 기사에 discription이 없을 경우 summary가 비어보이는 문제 수정
  - discription이 없으면 content를 가져오고, content도 없으면 title을 가져오도록 수정 

## 🔗 관련 이슈
- Closes #387 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
