### PR TITLE
[뉴스 기사] (Fix/398) 뉴스 기사 복구 안됨 에러 해결

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/batch/config/BackupBatchConfig.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/batch/config/BackupBatchConfig.java
@@ -107,7 +107,6 @@ public class BackupBatchConfig {
       if (articles.getItems().isEmpty()) {
         return;
       }
-//      String aggregatedJson = String.join("\n", articles.getItems());
 
       /** 저장되는 포맷:
        * [
@@ -119,8 +118,8 @@ public class BackupBatchConfig {
       String aggregatedJsonArray = objectMapper.writeValueAsString(articles.getItems());
 
       String filename = String.format(
-//          "test-articles-%s/chunk-%s.json",
-          "articles-%s/chunk-%s.json",
+//          "test-articles-%s/chunk-%s.json", // local
+          "articles-%s/chunk-%s.json", // test
           backupDateStr,
           UUID.randomUUID()
           );

--- a/src/main/java/com/sprint/team2/monew/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/repository/ArticleRepository.java
@@ -3,6 +3,7 @@ package com.sprint.team2.monew.domain.article.repository;
 import com.sprint.team2.monew.domain.article.entity.Article;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,12 +18,7 @@ public interface ArticleRepository extends JpaRepository<Article, UUID> {
 
     boolean existsBySourceUrlAndDeletedAtIsNull(String sourceUrl);
 
-    // gets non deleted (no soft delete)
-    @Query("SELECT a.sourceUrl FROM Article a"
-        + " WHERE a.createdAt >= :startDate AND a.createdAt < :endDate AND a.deletedAt IS NULL")
-    Set<String> findArticleUrlsBetweenDates(
-            @Param("startDate") LocalDateTime start,
-            @Param("endDate") LocalDateTime end);
+    List<Article> findByPublishDateBetween(LocalDateTime start, LocalDateTime end);
 
     @Modifying
     @Query("UPDATE Article a SET a.commentCount = a.commentCount + 1 WHERE a.id = :articleId")


### PR DESCRIPTION
## PR 제목 규칙
[뉴스 기사] (Fix/398) 뉴스 기사 복구 안됨 에러 해결

## 📌 PR 내용 요약
- 뉴스 기사 복구 안됨 에러 해결
  - createdAt대신 publishDate을 사용했더니 해결...

## 🔗 관련 이슈
- Closes #398

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)

## 🙋 리뷰어에게 요청사항
