### PR TITLE
[뉴스 기사] (Fix/413) 출처 목록 조회 오류 해결

### DIFF
--- a/src/main/java/com/sprint/team2/monew/domain/article/converter/ArticleSourceConverter.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/converter/ArticleSourceConverter.java
@@ -1,0 +1,13 @@
+package com.sprint.team2.monew.domain.article.converter;
+
+import com.sprint.team2.monew.domain.article.entity.ArticleSource;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArticleSourceConverter implements Converter<String, ArticleSource> {
+    @Override
+    public ArticleSource convert(String source) {
+        return ArticleSource.from(source);
+    }
+}

--- a/src/main/java/com/sprint/team2/monew/domain/article/entity/ArticleSource.java
+++ b/src/main/java/com/sprint/team2/monew/domain/article/entity/ArticleSource.java
@@ -18,4 +18,13 @@ public enum ArticleSource {
     public String getDisplayName() {
         return displayName;
     }
+
+    public static ArticleSource from(String value) {
+        for (ArticleSource source : values()) {
+            if (source.displayName.equals(value) || source.name().equalsIgnoreCase(value)) {
+                return source;
+            }
+        }
+        throw new IllegalArgumentException("Unknown ArticleSource: " + value);
+    }
 }


### PR DESCRIPTION
## PR 제목 규칙
[도메인] (기능분류/이슈카드번호) PR 내용 한 줄 요약

## 📌 PR 내용 요약
- ArticleSource enum에 displayName 필드를 추가하여 한글 출처명이 노출되도록 개선했는데 MethodArgumentTypeMismatchException 발생
- 역직렬화가 안되서 생긴 오류
- 영문 enum name과 한글 displayName 모두 요청 파라미터로 처리 가능하도록 from() 메서드 구현
- ArticleSourceConverter 추가

## 🔗 관련 이슈
- Closes #413 

## 🖼️ 스크린샷 (선택)


## 📚 참고자료 (선택)
- 

## 🙋 리뷰어에게 요청사항
- 
